### PR TITLE
Move testing utils into a sub package.

### DIFF
--- a/fasthash.go
+++ b/fasthash.go
@@ -1,0 +1,26 @@
+package fasthash
+
+import (
+	"encoding/binary"
+	"hash"
+)
+
+// HashString64 makes a hashing function from the hashing algorithm returned by f.
+func HashString64(f func() hash.Hash64) func(string) uint64 {
+	return func(s string) uint64 {
+		h := f()
+		h.Write([]byte(s))
+		return h.Sum64()
+	}
+}
+
+// HashUint64 makes a hashing function from the hashing algorithm return by f.
+func HashUint64(f func() hash.Hash64) func(uint64) uint64 {
+	return func(u uint64) uint64 {
+		b := [8]byte{}
+		binary.BigEndian.PutUint64(b[:], u)
+		h := f()
+		h.Write(b[:])
+		return h.Sum64()
+	}
+}

--- a/fasthash32.go
+++ b/fasthash32.go
@@ -1,0 +1,26 @@
+package fasthash
+
+import (
+	"encoding/binary"
+	"hash"
+)
+
+// HashString32 makes a hashing function from the hashing algorithm returned by f.
+func HashString32(f func() hash.Hash32) func(string) uint32 {
+	return func(s string) uint32 {
+		h := f()
+		h.Write([]byte(s))
+		return h.Sum32()
+	}
+}
+
+// HashUint32 makes a hashing function from the hashing algorithm return by f.
+func HashUint32(f func() hash.Hash32) func(uint32) uint32 {
+	return func(u uint32) uint32 {
+		b := [4]byte{}
+		binary.BigEndian.PutUint32(b[:], u)
+		h := f()
+		h.Write(b[:])
+		return h.Sum32()
+	}
+}

--- a/fasthashtest/fasthashtest.go
+++ b/fasthashtest/fasthashtest.go
@@ -1,30 +1,6 @@
-package fasthash
+package fasthashtest
 
-import (
-	"encoding/binary"
-	"hash"
-	"testing"
-)
-
-// HashString64 makes a hashing function from the hashing algorithm returned by f.
-func HashString64(f func() hash.Hash64) func(string) uint64 {
-	return func(s string) uint64 {
-		h := f()
-		h.Write([]byte(s))
-		return h.Sum64()
-	}
-}
-
-// HashUint64 makes a hashing function from the hashing algorithm return by f.
-func HashUint64(f func() hash.Hash64) func(uint64) uint64 {
-	return func(u uint64) uint64 {
-		b := [8]byte{}
-		binary.BigEndian.PutUint64(b[:], u)
-		h := f()
-		h.Write(b[:])
-		return h.Sum64()
-	}
-}
+import "testing"
 
 // TestHashString64 is the implementation of a test suite to verify the
 // behavior of a hashing algorithm.

--- a/fasthashtest/fasthashtest32.go
+++ b/fasthashtest/fasthashtest32.go
@@ -1,30 +1,6 @@
-package fasthash
+package fasthashtest
 
-import (
-	"encoding/binary"
-	"hash"
-	"testing"
-)
-
-// HashString32 makes a hashing function from the hashing algorithm returned by f.
-func HashString32(f func() hash.Hash32) func(string) uint32 {
-	return func(s string) uint32 {
-		h := f()
-		h.Write([]byte(s))
-		return h.Sum32()
-	}
-}
-
-// HashUint32 makes a hashing function from the hashing algorithm return by f.
-func HashUint32(f func() hash.Hash32) func(uint32) uint32 {
-	return func(u uint32) uint32 {
-		b := [4]byte{}
-		binary.BigEndian.PutUint32(b[:], u)
-		h := f()
-		h.Write(b[:])
-		return h.Sum32()
-	}
-}
+import "testing"
 
 // TestHashString32 is the implementation of a test suite to verify the
 // behavior of a hashing algorithm.

--- a/fnv1/hash32_test.go
+++ b/fnv1/hash32_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
 )
 
 func TestHash32(t *testing.T) {
-	fasthash.TestHashString32(t, "fnv1", fasthash.HashString32(fnv.New32), HashString32)
-	fasthash.TestHashUint32(t, "fnv1", fasthash.HashUint32(fnv.New32), HashUint32)
+	fasthashtest.TestHashString32(t, "fnv1", fasthash.HashString32(fnv.New32), HashString32)
+	fasthashtest.TestHashUint32(t, "fnv1", fasthash.HashUint32(fnv.New32), HashUint32)
 }
 
 func BenchmarkHash32(b *testing.B) {
-	fasthash.BenchmarkHashString32(b, "fnv1", fasthash.HashString32(fnv.New32a), HashString32)
+	fasthashtest.BenchmarkHashString32(b, "fnv1", fasthash.HashString32(fnv.New32a), HashString32)
 }

--- a/fnv1/hash_test.go
+++ b/fnv1/hash_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
 )
 
 func TestHash64(t *testing.T) {
-	fasthash.TestHashString64(t, "fnv1", fasthash.HashString64(fnv.New64), HashString64)
-	fasthash.TestHashUint64(t, "fnv1", fasthash.HashUint64(fnv.New64), HashUint64)
+	fasthashtest.TestHashString64(t, "fnv1", fasthash.HashString64(fnv.New64), HashString64)
+	fasthashtest.TestHashUint64(t, "fnv1", fasthash.HashUint64(fnv.New64), HashUint64)
 }
 
 func BenchmarkHash64(b *testing.B) {
-	fasthash.BenchmarkHashString64(b, "fnv1", fasthash.HashString64(fnv.New64a), HashString64)
+	fasthashtest.BenchmarkHashString64(b, "fnv1", fasthash.HashString64(fnv.New64a), HashString64)
 }

--- a/fnv1a/hash32_test.go
+++ b/fnv1a/hash32_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
 )
 
 func TestHash32(t *testing.T) {
-	fasthash.TestHashString32(t, "fnv1a", fasthash.HashString32(fnv.New32a), HashString32)
-	fasthash.TestHashUint32(t, "fnv1a", fasthash.HashUint32(fnv.New32a), HashUint32)
+	fasthashtest.TestHashString32(t, "fnv1a", fasthash.HashString32(fnv.New32a), HashString32)
+	fasthashtest.TestHashUint32(t, "fnv1a", fasthash.HashUint32(fnv.New32a), HashUint32)
 }
 
 func BenchmarkHash32(b *testing.B) {
-	fasthash.BenchmarkHashString32(b, "fnv1a", fasthash.HashString32(fnv.New32a), HashString32)
+	fasthashtest.BenchmarkHashString32(b, "fnv1a", fasthash.HashString32(fnv.New32a), HashString32)
 }

--- a/fnv1a/hash_test.go
+++ b/fnv1a/hash_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
 )
 
 func TestHash64(t *testing.T) {
-	fasthash.TestHashString64(t, "fnv1a", fasthash.HashString64(fnv.New64a), HashString64)
-	fasthash.TestHashUint64(t, "fnv1a", fasthash.HashUint64(fnv.New64a), HashUint64)
+	fasthashtest.TestHashString64(t, "fnv1a", fasthash.HashString64(fnv.New64a), HashString64)
+	fasthashtest.TestHashUint64(t, "fnv1a", fasthash.HashUint64(fnv.New64a), HashUint64)
 }
 
 func BenchmarkHash64(b *testing.B) {
-	fasthash.BenchmarkHashString64(b, "fnv1a", fasthash.HashString64(fnv.New64a), HashString64)
+	fasthashtest.BenchmarkHashString64(b, "fnv1a", fasthash.HashString64(fnv.New64a), HashString64)
 }

--- a/jody/hash_test.go
+++ b/jody/hash_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/segmentio/fasthash"
+	"github.com/segmentio/fasthash/fasthashtest"
 )
 
 func TestHash64(t *testing.T) {
@@ -34,10 +34,10 @@ func TestHash64(t *testing.T) {
 		return 0x0007cf56f7fc0ba3
 	}
 
-	fasthash.TestHashString64(t, "jody", referenceString64, HashString64)
-	fasthash.TestHashUint64(t, "jody", referenceUint64, HashUint64)
+	fasthashtest.TestHashString64(t, "jody", referenceString64, HashString64)
+	fasthashtest.TestHashUint64(t, "jody", referenceUint64, HashUint64)
 }
 
 func BenchmarkHash64(b *testing.B) {
-	fasthash.BenchmarkHashString64(b, "jody", nil, HashString64)
+	fasthashtest.BenchmarkHashString64(b, "jody", nil, HashString64)
 }


### PR DESCRIPTION
This helps simplify the API, and seperates the library into two packages:

a) one for the core package.

```
package fasthash

func HashString32(f func() hash.Hash32) func(string) uint32
func HashString64(f func() hash.Hash64) func(string) uint64
func HashUint32(f func() hash.Hash32) func(uint32) uint32
func HashUint64(f func() hash.Hash64) func(uint64) uint64
```

b) one for testing.

```
package fasthashtest

func BenchmarkHashString32(b *testing.B, name string, reference func(string) uint32, algorithm func(string) uint32)
func BenchmarkHashString64(b *testing.B, name string, reference func(string) uint64, algorithm func(string) uint64)
func TestHashString32(t *testing.T, name string, reference func(string) uint32, algorithm func(string) uint32)
func TestHashString64(t *testing.T, name string, reference func(string) uint64, algorithm func(string) uint64)
func TestHashUint32(t *testing.T, name string, reference func(uint32) uint32, algorithm func(uint32) uint32)
func TestHashUint64(t *testing.T, name string, reference func(uint64) uint64, algorithm func(uint64) uint64)
```

Closes #6.