### PR TITLE
optimize small strings

### DIFF
--- a/fasthashtest/fasthashtest.go
+++ b/fasthashtest/fasthashtest.go
@@ -1,12 +1,16 @@
 package fasthashtest
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 // TestHashString64 is the implementation of a test suite to verify the
 // behavior of a hashing algorithm.
 func TestHashString64(t *testing.T, name string, reference func(string) uint64, algorithm func(string) uint64) {
 	t.Run(name, func(t *testing.T) {
-		for _, s := range [...]string{"", "A", "Hello World!", "DAB45194-42CC-4106-AB9F-2447FA4D35C2"} {
+		for _, s := range [...]string{"", "A", "Hello World!", "DAB45194-42CC-4106-AB9F-2447FA4D35C2", "你好吗"} {
 			t.Run(s, func(t *testing.T) {
 				if reference == nil {
 					algorithm(s)
@@ -48,16 +52,24 @@ func BenchmarkHashString64(b *testing.B, name string, reference func(string) uin
 		if reference != nil {
 			b.Run("reference", func(b *testing.B) { benchmark(b, reference) })
 		}
-		b.Run("algorithm", func(b *testing.B) { benchmark(b, algorithm) })
+		b.Run("optimized", func(b *testing.B) { benchmark(b, algorithm) })
 	})
 }
 
+var benchmarkStrings = [...]string{
+	"asdf",
+	"hello world",
+	"DAB45194-42CC-4106-AB9F-2447FA4D35C2",
+	strings.Repeat("1234567890", 100),
+}
+
 func benchmark(b *testing.B, hash func(string) uint64) {
-	const uuid = "DAB45194-42CC-4106-AB9F-2447FA4D35C2"
-
-	for i := 0; i != b.N; i++ {
-		hash(uuid)
+	for _, s := range benchmarkStrings {
+		b.Run(fmt.Sprintf("strlen=%d", len(s)), func(b *testing.B) {
+			for i := 0; i != b.N; i++ {
+				hash(s)
+			}
+			b.SetBytes(int64(len(s)))
+		})
 	}
-
-	b.SetBytes(int64(len(uuid)))
 }

--- a/fasthashtest/fasthashtest32.go
+++ b/fasthashtest/fasthashtest32.go
@@ -1,12 +1,15 @@
 package fasthashtest
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 // TestHashString32 is the implementation of a test suite to verify the
 // behavior of a hashing algorithm.
 func TestHashString32(t *testing.T, name string, reference func(string) uint32, algorithm func(string) uint32) {
 	t.Run(name, func(t *testing.T) {
-		for _, s := range [...]string{"", "A", "Hello World!", "DAB45194-42CC-4106-AB9F-2447FA4D35C2"} {
+		for _, s := range [...]string{"", "A", "Hello World!", "DAB45194-42CC-4106-AB9F-2447FA4D35C2", "你好吗"} {
 			t.Run(s, func(t *testing.T) {
 				if reference == nil {
 					algorithm(s)
@@ -48,16 +51,17 @@ func BenchmarkHashString32(b *testing.B, name string, reference func(string) uin
 		if reference != nil {
 			b.Run("reference", func(b *testing.B) { benchmark32(b, reference) })
 		}
-		b.Run("algorithm", func(b *testing.B) { benchmark32(b, algorithm) })
+		b.Run("optimized", func(b *testing.B) { benchmark32(b, algorithm) })
 	})
 }
 
 func benchmark32(b *testing.B, hash func(string) uint32) {
-	const uuid = "DAB45194-42CC-4106-AB9F-2447FA4D35C2"
-
-	for i := 0; i != b.N; i++ {
-		hash(uuid)
+	for _, s := range benchmarkStrings {
+		b.Run(fmt.Sprintf("strlen=%d", len(s)), func(b *testing.B) {
+			for i := 0; i != b.N; i++ {
+				hash(s)
+			}
+			b.SetBytes(int64(len(s)))
+		})
 	}
-
-	b.SetBytes(int64(len(uuid)))
 }

--- a/fnv1/hash.go
+++ b/fnv1/hash.go
@@ -21,24 +21,34 @@ func HashUint64(u uint64) uint64 {
 
 // AddString64 adds the hash of s to the precomputed hash value h.
 func AddString64(h uint64, s string) uint64 {
-	i := 0
-	n := (len(s) / 8) * 8
-
-	for i != n {
-		h = (h * prime64) ^ uint64(s[i])
-		h = (h * prime64) ^ uint64(s[i+1])
-		h = (h * prime64) ^ uint64(s[i+2])
-		h = (h * prime64) ^ uint64(s[i+3])
-		h = (h * prime64) ^ uint64(s[i+4])
-		h = (h * prime64) ^ uint64(s[i+5])
-		h = (h * prime64) ^ uint64(s[i+6])
-		h = (h * prime64) ^ uint64(s[i+7])
-
-		i += 8
+	for len(s) >= 8 {
+		h = (h * prime64) ^ uint64(s[0])
+		h = (h * prime64) ^ uint64(s[1])
+		h = (h * prime64) ^ uint64(s[2])
+		h = (h * prime64) ^ uint64(s[3])
+		h = (h * prime64) ^ uint64(s[4])
+		h = (h * prime64) ^ uint64(s[5])
+		h = (h * prime64) ^ uint64(s[6])
+		h = (h * prime64) ^ uint64(s[7])
+		s = s[8:]
 	}
 
-	for _, c := range s[i:] {
-		h = (h * prime64) ^ uint64(c)
+	if len(s) >= 4 {
+		h = (h * prime64) ^ uint64(s[0])
+		h = (h * prime64) ^ uint64(s[1])
+		h = (h * prime64) ^ uint64(s[2])
+		h = (h * prime64) ^ uint64(s[3])
+		s = s[4:]
+	}
+
+	if len(s) >= 2 {
+		h = (h * prime64) ^ uint64(s[0])
+		h = (h * prime64) ^ uint64(s[1])
+		s = s[2:]
+	}
+
+	if len(s) > 0 {
+		h = (h * prime64) ^ uint64(s[0])
 	}
 
 	return h

--- a/fnv1/hash32.go
+++ b/fnv1/hash32.go
@@ -33,8 +33,22 @@ func AddString32(h uint32, s string) uint32 {
 		s = s[8:]
 	}
 
-	for i := range s {
-		h = (h * prime32) ^ uint32(s[i])
+	if len(s) >= 4 {
+		h = (h * prime32) ^ uint32(s[0])
+		h = (h * prime32) ^ uint32(s[1])
+		h = (h * prime32) ^ uint32(s[2])
+		h = (h * prime32) ^ uint32(s[3])
+		s = s[4:]
+	}
+
+	if len(s) >= 2 {
+		h = (h * prime32) ^ uint32(s[0])
+		h = (h * prime32) ^ uint32(s[1])
+		s = s[2:]
+	}
+
+	if len(s) > 0 {
+		h = (h * prime32) ^ uint32(s[0])
 	}
 
 	return h

--- a/fnv1/hash32.go
+++ b/fnv1/hash32.go
@@ -21,24 +21,20 @@ func HashUint32(u uint32) uint32 {
 
 // AddString32 adds the hash of s to the precomputed hash value h.
 func AddString32(h uint32, s string) uint32 {
-	i := 0
-	n := (len(s) / 8) * 8
-
-	for i != n {
-		h = (h * prime32) ^ uint32(s[i])
-		h = (h * prime32) ^ uint32(s[i+1])
-		h = (h * prime32) ^ uint32(s[i+2])
-		h = (h * prime32) ^ uint32(s[i+3])
-		h = (h * prime32) ^ uint32(s[i+4])
-		h = (h * prime32) ^ uint32(s[i+5])
-		h = (h * prime32) ^ uint32(s[i+6])
-		h = (h * prime32) ^ uint32(s[i+7])
-
-		i += 8
+	for len(s) >= 8 {
+		h = (h * prime32) ^ uint32(s[0])
+		h = (h * prime32) ^ uint32(s[1])
+		h = (h * prime32) ^ uint32(s[2])
+		h = (h * prime32) ^ uint32(s[3])
+		h = (h * prime32) ^ uint32(s[4])
+		h = (h * prime32) ^ uint32(s[5])
+		h = (h * prime32) ^ uint32(s[6])
+		h = (h * prime32) ^ uint32(s[7])
+		s = s[8:]
 	}
 
-	for _, c := range s[i:] {
-		h = (h * prime32) ^ uint32(c)
+	for i := range s {
+		h = (h * prime32) ^ uint32(s[i])
 	}
 
 	return h

--- a/fnv1a/hash.go
+++ b/fnv1a/hash.go
@@ -34,24 +34,34 @@ func AddString64(h uint64, s string) uint64 {
 		- BenchmarkHash64/hash_function-4   50000000   38.6 ns/op   932.35 MB/s   0 B/op   0 allocs/op
 
 	*/
-
-	i := 0
-	n := (len(s) / 8) * 8
-
-	for i != n {
-		h = (h ^ uint64(s[i])) * prime64
-		h = (h ^ uint64(s[i+1])) * prime64
-		h = (h ^ uint64(s[i+2])) * prime64
-		h = (h ^ uint64(s[i+3])) * prime64
-		h = (h ^ uint64(s[i+4])) * prime64
-		h = (h ^ uint64(s[i+5])) * prime64
-		h = (h ^ uint64(s[i+6])) * prime64
-		h = (h ^ uint64(s[i+7])) * prime64
-		i += 8
+	for len(s) >= 8 {
+		h = (h ^ uint64(s[0])) * prime64
+		h = (h ^ uint64(s[1])) * prime64
+		h = (h ^ uint64(s[2])) * prime64
+		h = (h ^ uint64(s[3])) * prime64
+		h = (h ^ uint64(s[4])) * prime64
+		h = (h ^ uint64(s[5])) * prime64
+		h = (h ^ uint64(s[6])) * prime64
+		h = (h ^ uint64(s[7])) * prime64
+		s = s[8:]
 	}
 
-	for _, c := range s[i:] {
-		h = (h ^ uint64(c)) * prime64
+	if len(s) >= 4 {
+		h = (h ^ uint64(s[0])) * prime64
+		h = (h ^ uint64(s[1])) * prime64
+		h = (h ^ uint64(s[2])) * prime64
+		h = (h ^ uint64(s[3])) * prime64
+		s = s[4:]
+	}
+
+	if len(s) >= 2 {
+		h = (h ^ uint64(s[0])) * prime64
+		h = (h ^ uint64(s[1])) * prime64
+		s = s[2:]
+	}
+
+	if len(s) > 0 {
+		h = (h ^ uint64(s[0])) * prime64
 	}
 
 	return h

--- a/fnv1a/hash32.go
+++ b/fnv1a/hash32.go
@@ -21,23 +21,34 @@ func HashUint32(u uint32) uint32 {
 
 // AddString32 adds the hash of s to the precomputed hash value h.
 func AddString32(h uint32, s string) uint32 {
-	i := 0
-	n := (len(s) / 8) * 8
-
-	for i != n {
-		h = (h ^ uint32(s[i])) * prime32
-		h = (h ^ uint32(s[i+1])) * prime32
-		h = (h ^ uint32(s[i+2])) * prime32
-		h = (h ^ uint32(s[i+3])) * prime32
-		h = (h ^ uint32(s[i+4])) * prime32
-		h = (h ^ uint32(s[i+5])) * prime32
-		h = (h ^ uint32(s[i+6])) * prime32
-		h = (h ^ uint32(s[i+7])) * prime32
-		i += 8
+	for len(s) >= 8 {
+		h = (h ^ uint32(s[0])) * prime32
+		h = (h ^ uint32(s[1])) * prime32
+		h = (h ^ uint32(s[2])) * prime32
+		h = (h ^ uint32(s[3])) * prime32
+		h = (h ^ uint32(s[4])) * prime32
+		h = (h ^ uint32(s[5])) * prime32
+		h = (h ^ uint32(s[6])) * prime32
+		h = (h ^ uint32(s[7])) * prime32
+		s = s[8:]
 	}
 
-	for _, c := range s[i:] {
-		h = (h ^ uint32(c)) * prime32
+	if len(s) >= 4 {
+		h = (h ^ uint32(s[0])) * prime32
+		h = (h ^ uint32(s[1])) * prime32
+		h = (h ^ uint32(s[2])) * prime32
+		h = (h ^ uint32(s[3])) * prime32
+		s = s[4:]
+	}
+
+	if len(s) >= 2 {
+		h = (h ^ uint32(s[0])) * prime32
+		h = (h ^ uint32(s[1])) * prime32
+		s = s[2:]
+	}
+
+	if len(s) > 0 {
+		h = (h ^ uint32(s[0])) * prime32
 	}
 
 	return h

--- a/jody/hash_test.go
+++ b/jody/hash_test.go
@@ -22,6 +22,8 @@ func TestHash64(t *testing.T) {
 			return 0x60be57b5a53eb1c7
 		case "DAB45194-42CC-4106-AB9F-2447FA4D35C2":
 			return 0x587861d2b41e1997
+		case "你好吗":
+			return 0x944cd5c16171eca3
 		default:
 			panic("test not implemented: " + s)
 		}


### PR DESCRIPTION
This PR adds a couple of loop-unrolling code to reduce the number of iterations when dealing with small strings:
```
benchmark                                       old ns/op     new ns/op     delta
BenchmarkHash32/fnv1a/optimized/strlen=4        6.05          4.26          -29.59%
BenchmarkHash32/fnv1a/optimized/strlen=11       7.98          7.66          -4.01%
BenchmarkHash32/fnv1a/optimized/strlen=36       22.9          22.0          -3.93%
BenchmarkHash32/fnv1a/optimized/strlen=1000     870           874           +0.46%
BenchmarkHash64/fnv1a/optimized/strlen=4        6.42          4.88          -23.99%
BenchmarkHash64/fnv1a/optimized/strlen=11       8.44          7.51          -11.02%
BenchmarkHash64/fnv1a/optimized/strlen=36       23.5          23.3          -0.85%
BenchmarkHash64/fnv1a/optimized/strlen=1000     896           887           -1.00%

benchmark                                       old MB/s     new MB/s     speedup
BenchmarkHash32/fnv1a/optimized/strlen=4        660.81       938.89       1.42x
BenchmarkHash32/fnv1a/optimized/strlen=11       1378.41      1435.13      1.04x
BenchmarkHash32/fnv1a/optimized/strlen=36       1575.06      1633.63      1.04x
BenchmarkHash32/fnv1a/optimized/strlen=1000     1149.21      1143.00      0.99x
BenchmarkHash64/fnv1a/optimized/strlen=4        622.81       820.06       1.32x
BenchmarkHash64/fnv1a/optimized/strlen=11       1303.70      1463.94      1.12x
BenchmarkHash64/fnv1a/optimized/strlen=36       1533.61      1547.72      1.01x
BenchmarkHash64/fnv1a/optimized/strlen=1000     1114.86      1127.09      1.01x
```