### PR TITLE
Fix segfault in jody hash

### DIFF
--- a/jody/hash.go
+++ b/jody/hash.go
@@ -97,9 +97,22 @@ func AddString64(h uint64, s string) uint64 {
 	}
 
 	if n := (r.Len & 7); n != 0 {
-		m := mask64[n]
-		c := constant & m
-		v := *(*uint64)(p) & m // risk of segfault here?
+		c := constant & mask64[n]
+		var v uint64
+		off := uint(0)
+		if 0 != (n & 4) {
+			v += uint64(*(*uint32)(p))
+			off += 32
+			p = unsafe.Pointer(uintptr(p) + 4)
+		}
+		if 0 != (n & 2) {
+			v += uint64(*(*uint16)(p)) << off
+			off += 16
+			p = unsafe.Pointer(uintptr(p) + 2)
+		}
+		if 0 != (n & 1) {
+			v += uint64(*(*uint8)(p)) << off
+		}
 
 		h = h + v + c
 		h = (h<<shift | h>>(64-shift)) ^ v

--- a/jody/hash.go
+++ b/jody/hash.go
@@ -98,7 +98,7 @@ func AddString64(h uint64, s string) uint64 {
 
 	if n := (r.Len & 7); n != 0 {
 		c := constant & mask64[n]
-		var v uint64
+		v := uint64(0)
 		off := uint(0)
 		if 0 != (n & 4) {
 			v += uint64(*(*uint32)(p))


### PR DESCRIPTION
One application of mine has suddenly crashed after running for weeks without a glitch. The system is Intel Xeon E5-2620 v4.

Here's relevant part of the backtrace:
```
goroutine 15 [running]:
runtime.throw(0x855148, 0x5)
        /usr/local/go/src/runtime/panic.go:1114 +0x72 fp=0xc00004c930 sp=0xc00004c900 pc=0x435c22
runtime.sigpanic()
        /usr/local/go/src/runtime/signal_unix.go:702 +0x3cc fp=0xc00004c960 sp=0xc00004c930 pc=0x44b82c
github.com/segmentio/fasthash/jody.AddString64(0x209c71d594e51d87, 0xc0c3fffffa, 0x3, 0x209c71d594e51d87)
        /root/go/pkg/mod/github.com/segmentio/fasthash@v1.0.1/jody/hash.go:102 +0x74 fp=0xc00004c968 sp=0xc00004c960 pc=0x6f25b4
github.com/segmentio/stats/v4/prometheus.labels.hash(0xc0a3df4400, 0x4, 0x8, 0x0)
        /root/go/pkg/mod/github.com/segmentio/stats/v4@v4.5.3/prometheus/label.go:52 +0x82 fp=0xc00004c9a8 sp=0xc00004c968 pc=0x6f5442
github.com/segmentio/stats/v4/prometheus.(*metricEntry).lookup(0xc0001e6090, 0xc0a3df4400, 0x4, 0x8, 0x791450)
        /root/go/pkg/mod/github.com/segmentio/stats/v4@v4.5.3/prometheus/metric.go:166 +0x4c fp=0xc00004ca20 sp=0xc00004c9a8 pc=0x6f65dc
github.com/segmentio/stats/v4/prometheus.(*metricStore).update(0xddb988, 0x1, 0xc08c3fa1a0, 0x6, 0x791450, 0x7, 0x0, 0x0, 0x3ff0000000000000, 0xbfab90f0eb145aab, ...)
        /root/go/pkg/mod/github.com/segmentio/stats/v4@v4.5.3/prometheus/metric.go:100 +0xe4 fp=0xc00004cae8 sp=0xc00004ca20 pc=0x6f60f4
github.com/segmentio/stats/v4/prometheus.(*Handler).HandleMeasures(0xddb960, 0xbfab90f0eb145aab, 0x1a6b4e897307, 0xddba20, 0xc08d884000, 0x1, 0x20)
        /root/go/pkg/mod/github.com/segmentio/stats/v4@v4.5.3/prometheus/handler.go:76 +0x5ed fp=0xc00004cd38 sp=0xc00004cae8 pc=0x6f44dd
github.com/segmentio/stats/v4.(*Engine).ReportAt(0xc000067dc0, 0xbfab90f0eb145aab, 0x1a6b4e897307, 0xddba20, 0x7e9440, 0xc08920b1a0, 0xc00012c000, 0x4, 0x8)
        /root/go/pkg/mod/github.com/segmentio/stats/v4@v4.5.3/engine.go:207 +0x22e fp=0xc00004ce28 sp=0xc00004cd38 pc=0x6ebd9e
github.com/segmentio/stats/v4.(*Engine).Report(0xc000067dc0, 0x7e9440, 0xc08920b1a0, 0xc00012c000, 0x4, 0xa)
        /root/go/pkg/mod/github.com/segmentio/stats/v4@v4.5.3/engine.go:183 +0x82 fp=0xc00004ce80 sp=0xc00004ce28 pc=0x6ebb52
```

I haven't been able to reproduce it again since then. As you can see the panic issued by this piece of code here https://github.com/segmentio/fasthash/blob/f3727d1efd1ebf7ce313d35dea4ad7096d92e72d/jody/hash.go#L102 which has comment about potential segfault. :)

I've fixed hash computation on tail data. Unfortunately this leads to some performance degradation but I haven't found a way to avoid it.

```
name                     old time/op    new time/op    delta
Hash64/jody/algorithm-4    12.7ns ± 1%    13.3ns ± 1%  +4.99%  (p=0.000 n=19+20)

name                     old speed      new speed      delta
Hash64/jody/algorithm-4  2.83GB/s ± 2%  2.70GB/s ± 1%  -4.65%  (p=0.000 n=19+20)
```